### PR TITLE
Remove screenshot link from the podspec

### DIFF
--- a/MapboxCoreMaps.podspec
+++ b/MapboxCoreMaps.podspec
@@ -10,7 +10,6 @@ Pod::Spec.new do |m|
   m.homepage = 'https://docs.mapbox.com/ios/maps/'
   m.license = { type: 'Commercial', file: 'LICENSE.md' }
   m.author = { 'Mapbox' => 'mobile@mapbox.com' }
-  m.screenshot = "https://docs.mapbox.com/ios/maps/api/#{version}/img/screenshot.png"
   m.social_media_url = 'https://twitter.com/mapbox'
   m.documentation_url = 'https://docs.mapbox.com/ios/beta/maps/guides/install/'
 


### PR DESCRIPTION
This PR removes the screenshot link from the MapboxCoreMaps.podspec. The URL wouldn't be valid, since it uses the Mapbox Core Maps version rather than the Maps iOS SDK version.

Noting that the pod spec may still fail due to https://github.com/CocoaPods/CocoaPods/issues/10291, but we can use `--allow-warnings` until CocoaPods v1.0.2 lands.