### PR TITLE
Update podspec for v10.0.0-beta.14.2

### DIFF
--- a/MapboxCoreMaps.podspec
+++ b/MapboxCoreMaps.podspec
@@ -13,7 +13,7 @@ Pod::Spec.new do |m|
   m.social_media_url = 'https://twitter.com/mapbox'
   m.documentation_url = 'https://docs.mapbox.com/ios/beta/maps/guides/install/'
 
-  m.source = { http: "https://api.mapbox.com/downloads/v2/mobile-maps-core/releases/ios/packages/#{version.to_s}/MapboxCoreMaps.xcframework-dynamic.zip" }
+  m.source = { http: "https://api.mapbox.com/downloads/v2/mobile-maps-core/releases/ios/packages/#{version.to_s}/MapboxCoreMaps.xcframework.zip" }
 
   m.platform = :ios
   m.ios.deployment_target = '11.0'


### PR DESCRIPTION
This PR removes the `-dynamic` suffix from the MapboxCoreMaps file name. We will want to reintroduce it for the next beta release.