### PR TITLE
Fix MapboxCommon version requirement

### DIFF
--- a/MapboxCoreMaps.podspec
+++ b/MapboxCoreMaps.podspec
@@ -22,6 +22,6 @@ Pod::Spec.new do |m|
 
   m.vendored_frameworks = 'MapboxCoreMaps.xcframework'
 
-  m.dependency 'MapboxCommon', '~> 21.3'
+  m.dependency 'MapboxCommon', '~> 22.0.0-beta'
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
             targets: ["MapboxCoreMapsWrapper"]),
     ],
     dependencies: [
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "21.3.0"),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "22.0.0-beta.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
Version requirement for v10.6.0-beta.3 was incorrect after bad merge conflict resolution in #68 