### PR TITLE
Revert "Merge pull request #160 from mapbox/11.3.2"

### DIFF
--- a/MapboxCoreMaps.podspec
+++ b/MapboxCoreMaps.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |m|
 
-  version = '11.3.2'
+  version = '11.4.0-beta.1'
 
   m.name = 'MapboxCoreMaps'
   m.version = version
@@ -22,6 +22,6 @@ Pod::Spec.new do |m|
 
   m.vendored_frameworks = 'MapboxCoreMaps.xcframework'
 
-  m.dependency 'MapboxCommon', '~> 24.3'
+  m.dependency 'MapboxCommon', '~> 24.4.0-beta'
 
 end

--- a/Package.swift
+++ b/Package.swift
@@ -4,8 +4,8 @@
 import PackageDescription
 import Foundation
 
-let version = "11.3.2"
-let checksum = "49bc0701fde8e5f7f05c37cc7e6bd879fcb20c0650c2730a36e09923643dc433"
+let version = "11.4.0-beta.1"
+let checksum = "b4b271fc9b323cebd91caee33b02d1a4188480d0880984897f413dc2961777ef"
 
 let package = Package(
     name: "MapboxCoreMaps",
@@ -16,7 +16,7 @@ let package = Package(
             targets: ["MapboxCoreMapsWrapper"]),
     ],
     dependencies: [
-        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "24.3.1"),
+        .package(name: "MapboxCommon", url: "https://github.com/mapbox/mapbox-common-ios.git", from: "24.4.0-beta.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
This reverts commit 7c88d48b2c11ae802f1ed858e182e3994d3c74d4, reversing changes made to 40da10b7dd365ef2350a35ccb5abefe726a0761c.

No longer releasing 11.3.2. Reverts: https://github.com/mapbox/mapbox-core-maps-ios/pull/160 